### PR TITLE
Add simple client-side to-do app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Delightful To-Do App
+
+This repository hosts a simple, client-side to-do application that runs in the browser. Tasks are stored in your browser's `localStorage` so they persist across refreshes.
+
+## Run locally
+
+Use a static file server to view the app. Python's built-in server works well:
+
+```bash
+python3 -m http.server
+```
+
+Then open <http://localhost:8000> in your browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Delightful To-Do List</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="app">
+    <h1>Delightful To-Do List</h1>
+    <form id="todo-form">
+      <input id="new-item" placeholder="What needs to be done?" autocomplete="off" />
+      <button type="submit">Add</button>
+    </form>
+    <ul id="todo-list"></ul>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,3 +1,0 @@
-## welcome to the webpage
-
-The work i wanted to showcase

--- a/script.js
+++ b/script.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('todo-form');
+  const input = document.getElementById('new-item');
+  const list = document.getElementById('todo-list');
+
+  const todos = JSON.parse(localStorage.getItem('todos') || '[]');
+  todos.forEach(addTodoToDOM);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (text) {
+      const todo = { text, done: false };
+      todos.push(todo);
+      save();
+      addTodoToDOM(todo);
+      input.value = '';
+    }
+  });
+
+  function addTodoToDOM(todo) {
+    const li = document.createElement('li');
+    li.textContent = todo.text;
+    if (todo.done) li.classList.add('done');
+
+    li.addEventListener('click', () => {
+      todo.done = !todo.done;
+      save();
+      li.classList.toggle('done');
+    });
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '\u2715';
+    removeBtn.className = 'remove';
+    removeBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      const idx = todos.indexOf(todo);
+      if (idx > -1) {
+        todos.splice(idx, 1);
+        save();
+        li.remove();
+      }
+    });
+
+    li.appendChild(removeBtn);
+    list.appendChild(li);
+  }
+
+  function save() {
+    localStorage.setItem('todos', JSON.stringify(todos));
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,61 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f7f7f7;
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+
+.app {
+  margin-top: 3rem;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 90%;
+  max-width: 400px;
+}
+
+form {
+  display: flex;
+}
+
+input {
+  flex: 1;
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  margin-left: 0.5rem;
+  cursor: pointer;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+  cursor: pointer;
+}
+
+li.done {
+  text-decoration: line-through;
+  color: #999;
+}
+
+button.remove {
+  background: none;
+  border: none;
+  color: #c00;
+  font-weight: bold;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- replace placeholder page with a localStorage-backed to-do list
- add simple styling and JavaScript
- document how to serve the site locally

## Testing
- `npm test` *(fails: could not read package.json)*
- `timeout 3 python3 -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_e_688cf7ea922c8325a227394b75bfb093